### PR TITLE
Simplify Soroswap events contract checks

### DIFF
--- a/static/stellar-rpc.js
+++ b/static/stellar-rpc.js
@@ -255,23 +255,18 @@ class StellarRPCClient {
       });
       console.log("soroswap pair: getEvents result:", result);
 
-      let nativeMatched = false;
-      let tokenMatched = false;
       for (const event of result.events) {
         const valueJson = xdr.decode_stream("ScVal", event.value);
         const value = JSON.parse(valueJson);
         for (const mapEntry of value.map) {
           if (mapEntry.key["symbol"] == "token_0" || mapEntry.key["symbol"] == "token_1") {
-            if (mapEntry.val["address"] == this.nativeAssetContract) {
-              nativeMatched = true;
-            }
             if (mapEntry.val["address"] == contractAddress) {
-              tokenMatched = true;
+              return true;
             }
           }
         }
       }
-      return nativeMatched && tokenMatched;
+      return false;
     } catch (error) {
       console.error("Error checking Soroswap pair:", error);
       return false;
@@ -303,23 +298,18 @@ class StellarRPCClient {
       });
       console.log("soroswap liquidity: getEvents result:", result);
 
-      let nativeMatched = false;
-      let tokenMatched = false;
       for (const event of result.events) {
         const valueJson = xdr.decode_stream("ScVal", event.value);
         const value = JSON.parse(valueJson);
         for (const mapEntry of value.map) {
           if (mapEntry.key["symbol"] == "token_a" || mapEntry.key["symbol"] == "token_b") {
-            if (mapEntry.val["address"] == this.nativeAssetContract) {
-              nativeMatched = true;
-            }
             if (mapEntry.val["address"] == contractAddress) {
-              tokenMatched = true;
+              return true;
             }
           }
         }
       }
-      return nativeMatched && tokenMatched;
+      return false;
     } catch (error) {
       console.error("Error checking Soroswap liquidity:", error);
       return false;


### PR DESCRIPTION
### What
  Simplify the contract validation logic in Soroswap pair and liquidity events by returning true as soon as the target contract address is found instead of also checking for if the event relates to the native asset.

  ### Why
  The previous implementation unnecessarily checked for both native and token contracts, when finding just the target contract is sufficient at showing the token is swapping or has liquidity with some other token, any other token.