### PR TITLE
Catch mint events with 2 or 3 topics

### DIFF
--- a/static/stellar-rpc.js
+++ b/static/stellar-rpc.js
@@ -242,7 +242,10 @@ class StellarRPCClient {
         filters: [{
           type: "contract",
           contractIds: [contractAddress],
-          topics: [[mintSymbol, "*"]],
+          topics: [
+            [mintSymbol, "*"],
+            [mintSymbol, "*", "*"],
+          ],
         }],
         startLedger,
         pagination: {


### PR DESCRIPTION
### What
  Update event filtering to capture mint events that have either 2 or 3 topics.

  ### Why
  Some contracts emit mint events with an additional parameter, causing them to be missed by the current filter configuration.